### PR TITLE
Fix `enum class Token` type safety

### DIFF
--- a/.github/workflows/cmake_windows_x86.yml
+++ b/.github/workflows/cmake_windows_x86.yml
@@ -25,12 +25,15 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       #run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-      run: cmake -G "Visual Studio 16 2019" -A Win64 -B ${{github.workspace}}/build -S ${{github.workspace}}/src
+      run: cmake -G "Visual Studio 16 2019" -B ${{github.workspace}}\build -S ${{github.workspace}}\src
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Build
       # Build your program with the given configuration
       #run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-      run: msbuild.exe ${{github.workspace}}\el.sln /property:Configuration=Release
+      run: msbuild.exe -m ${{github.workspace}}\build\el.sln /property:Configuration=Release
 
     #- name: Test
     #  working-directory: ${{github.workspace}}/build

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -1,6 +1,15 @@
 #ifndef LEXER_H
 #define LEXER_H
 
-int get_token(std::FILE*);
+enum class Token{
+	tok_eof = -1,
+	tok_def = -2,
+	tok_extern = -3,
+	tok_identifier = -4,
+	tok_number = -5,
+	tok_undefined = -6
+};
+
+Token get_token(std::FILE*);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,11 +47,12 @@ int main(int argc, char* argv[]){
 
 	std::cout << "Opened " << argv[1] << std::endl;
 
-	int next_token;
-	while((next_token = get_token(ifs)) != -1){
-		std::cout << next_token << std::endl;
+	Token next_token;
+	while((next_token = get_token(ifs)) != Token::tok_eof){
+		std::cout << (int)next_token << std::endl;
 		//;
 	}
+
 	std::fclose(ifs);
 	std::cout << "Closed " << argv[1] << std::endl;
 


### PR DESCRIPTION
The prototype for `get_tok()` used an `int` as its return type when it
should've been `Token`. This caused strange issues with MSVC.

Additionally, `next_token` was of type `int` instead of `Token`.