### PR TITLE
Fix test suite debug build

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,8 +22,4 @@ target_link_libraries(
     gtest_main
     ${llvm_libs})
 
-if(UNIX)
-    set(CMAKE_CXX_FLAGS "-g -Og -Werror")
-endif()
-
 target_include_directories(el_test PUBLIC ${PROJECT_SOURCE_DIR}/../include)


### PR DESCRIPTION
The `CMAKE_CXX_FLAGS` set in `test/CMakeLists.txt` were being ignored and
the incorrect optimization level was being used.

Remove setting of `CMAKE_CXX_FLAGS` in `/tets/CMakeLists.txt`.